### PR TITLE
Support error-only unary message responses

### DIFF
--- a/grpc-actix/src/future.rs
+++ b/grpc-actix/src/future.rs
@@ -52,7 +52,7 @@ where
     S: Stream,
     S::Error: Into<Status>,
 {
-    type Item = S::Item;
+    type Item = Option<S::Item>;
     type Error = Status;
 
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
@@ -77,14 +77,7 @@ where
                 }
 
                 Ok(Async::Ready(None)) => {
-                    return match self.item.take() {
-                        None => Err(Status::new(
-                            StatusCode::Unimplemented,
-                            Some("expected single-message body, received no messages"),
-                        )),
-
-                        Some(item) => Ok(Async::Ready(item)),
-                    };
+                    return Ok(Async::Ready(self.item.take()));
                 }
 
                 Err(e) => {


### PR DESCRIPTION
The gRPC specification allows responses to be sent without any message
data if returning an error (non-zero status code). For unary message
responses, the current client implementation always returns an
"UNIMPLEMENTED" status code to the user if the message data is missing,
even if a non-zero status code was returned by the server. This change
addresses the issue by forwarding the non-zero status to the user if
found, falling back on the "UNIMPLEMENTED" status error if the status
code is zero.

Fixes #17.