### PR TITLE
Make thread_pool public as a module of grpc-actix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,5 @@
 [workspace]
 members = [
     "grpc-actix",
-    "grpc-actix-build",
-    "thread-pool"
+    "grpc-actix-build"
 ]

--- a/grpc-actix/Cargo.toml
+++ b/grpc-actix/Cargo.toml
@@ -16,7 +16,6 @@ hyper = { git = "https://github.com/tokenio/hyper.git", version = "^0.12.9" }
 log = "0.4"
 parking_lot = "0.6"
 prost = "0.4"
-thread-pool = { path = "../thread-pool" }
 
 [dev-dependencies]
 prost-derive = "0.4"

--- a/grpc-actix/src/lib.rs
+++ b/grpc-actix/src/lib.rs
@@ -12,7 +12,6 @@ extern crate hyper;
 extern crate log;
 extern crate parking_lot;
 extern crate prost;
-pub extern crate thread_pool;
 
 #[cfg(test)]
 #[macro_use]
@@ -29,6 +28,8 @@ mod response;
 mod server;
 mod status;
 mod util;
+
+pub mod thread_pool;
 
 pub use client::*;
 pub use future::*;

--- a/grpc-actix/src/thread_pool.rs
+++ b/grpc-actix/src/thread_pool.rs
@@ -1,7 +1,3 @@
-extern crate actix;
-extern crate futures;
-extern crate tokio;
-
 use actix::{Addr, Arbiter, Context, Handler, Message, Response};
 use futures::future::{ExecuteError, ExecuteErrorKind, Executor};
 use futures::Future;
@@ -108,7 +104,7 @@ mod tests {
     use futures::future::Executor;
     use futures::{future, Future};
     use std::sync::{Arc, Mutex};
-    use {ArbiterExecutor, CircularVector, Pool};
+    use thread_pool::{ArbiterExecutor, CircularVector, Pool};
 
     #[test]
     fn test_circular_vector() {

--- a/thread-pool/Cargo.toml
+++ b/thread-pool/Cargo.toml
@@ -1,9 +1,0 @@
-[package]
-name = "thread-pool"
-version = "0.1.0"
-authors = ["Sascha Wise <me@saschawise.com>"]
-
-[dependencies]
-actix = "0.7"
-futures = "0.1"
-tokio = "0.1"


### PR DESCRIPTION
I want to make thread_pool something that anyone using the core grpc-actix crate can depend on. I think it is better to make it a submodule as I don't think our thread_pool implementation is super well designed and I don't think it should be published as it's own crate. 