### PR TITLE
Add client-side timing support

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,18 +2,34 @@ node('ec2') {
   checkout scm
   stage('Build') {
     sshagent (credentials: ['fd52c993-fb69-43d2-95fd-62a6a89baf0e']) {
+      dir('grpc-actix') {
         sh '/home/ubuntu/.cargo/bin/cargo build'
+        sh '/home/ubuntu/.cargo/bin/cargo build --features timing'
+      }
+      dir('grpc-actix-build') {
+        sh '/home/ubuntu/.cargo/bin/cargo build'
+      }
     }
   }
   try {
     stage('Test') {
-      sh '/home/ubuntu/.cargo/bin/cargo test | /home/ubuntu/.cargo/bin/cargo_test_formatter > test.xml'
+      dir('grpc-actix') {
+        sh '/home/ubuntu/.cargo/bin/cargo test | /home/ubuntu/.cargo/bin/cargo_test_formatter > ../test-default.xml'
+        sh '/home/ubuntu/.cargo/bin/cargo test --features timing | /home/ubuntu/.cargo/bin/cargo_test_formatter > ../test-timing.xml'
+      }
     }
   } finally {
-    junit 'test.xml'
+    junit 'test-default.xml'
+    junit 'test-timing.xml'
   }
   stage('Clippy') {
-    sh '/home/ubuntu/.cargo/bin/cargo +nightly clippy --all -- -Dwarnings'
+    dir('grpc-actix') {
+      sh '/home/ubuntu/.cargo/bin/cargo +nightly clippy --all -- -Dwarnings'
+      sh '/home/ubuntu/.cargo/bin/cargo +nightly clippy --all --features timing -- -Dwarnings'
+    }
+    dir('grpc-actix-build') {
+      sh '/home/ubuntu/.cargo/bin/cargo +nightly clippy --all -- -Dwarnings'
+    }
   }
   stage('Format') {
     sh '/home/ubuntu/.cargo/bin/cargo +nightly fmt -- --check'

--- a/grpc-actix/Cargo.toml
+++ b/grpc-actix/Cargo.toml
@@ -5,6 +5,12 @@ authors = ["Theodore Cipicchio <okready@users.noreply.github.com>", "Sascha Wise
 description = "Actor-based gRPC client and server implementation"
 license = "MIT"
 
+[features]
+default = []
+
+# Additional support for client-side timing of RPC requests.
+timing = ["tokio"]
+
 [dependencies]
 actix = "0.7"
 base64 = "0.9"
@@ -16,6 +22,8 @@ hyper = { git = "https://github.com/tokenio/hyper.git", version = "^0.12.9" }
 log = "0.4"
 parking_lot = "0.6"
 prost = "0.4"
+
+tokio = { version = "0.1", optional = true }
 
 [dev-dependencies]
 prost-derive = "0.4"

--- a/grpc-actix/src/client.rs
+++ b/grpc-actix/src/client.rs
@@ -17,6 +17,13 @@ use http::uri::Uri;
 use hyper::client::HttpConnector;
 use std::sync::Arc;
 
+#[cfg(feature = "timing")]
+use parking_lot::Mutex;
+#[cfg(feature = "timing")]
+use std::time::Instant;
+#[cfg(feature = "timing")]
+use tokio::prelude::task;
+
 /// [`future::Executor`] for client background `Connection` tasks.
 ///
 /// [`future::Executor`]: https://docs.rs/futures/0.1/futures/future/trait.Executor.html
@@ -98,14 +105,131 @@ impl Client {
         });
 
         Box::new(uri_future.and_then(move |uri| {
+            // `result_future` is modified at various points in the `and_then()` closure below
+            // depending on whether the "timing" feature is enabled, so it's cleaner for us to
+            // re-"let" it and return the final variable instead of trying to accommodate the
+            // `let_and_return` lint.
+            #[allow(unknown_lints, let_and_return)]
             request
                 .into_http_request(uri)
                 .and_then(move |http_request| {
-                    http_client
-                        .request(http_request)
-                        .map_err(Status::from)
-                        .and_then(ResponseT::from_http_response)
+                    #[cfg(feature = "timing")]
+                    let request_time = Instant::now();
+
+                    let result_future = http_client.request(http_request);
+
+                    // The response future is unparked multiple times before the final result is
+                    // yielded, but the first occurs when the task scheduler receives (or begins
+                    // receiving) the HTTP response over the connection socket. Subsequent unparks
+                    // occur after future processing begins within support libraries, and as such
+                    // can occur after arbitrary delays based on when the task scheduler gets around
+                    // to continuing future processing, so the first unpark is going to give us the
+                    // least possible variation in timing.
+                    #[cfg(feature = "timing")]
+                    let result_future = InitialUnparkTimeFuture::new(result_future);
+
+                    let result_future =
+                        result_future
+                            .map_err(Status::from)
+                            .and_then(|http_response| {
+                                #[cfg(feature = "timing")]
+                                let (http_response, unpark_times) = http_response;
+
+                                let result = ResponseT::from_http_response(http_response);
+
+                                #[cfg(feature = "timing")]
+                                let result = result.map(move |response| (response, unpark_times));
+
+                                result
+                            });
+
+                    #[cfg(feature = "timing")]
+                    let result_future = result_future.map(move |(mut response, unpark_times)| {
+                        response.set_timing(
+                            request_time,
+                            Arc::try_unwrap(unpark_times).unwrap().get().unwrap(),
+                        );
+                        response
+                    });
+
+                    result_future
                 })
         }))
+    }
+}
+
+/// Future that wraps polling of another future, tracking when the task is initially unparked.
+#[cfg(feature = "timing")]
+struct InitialUnparkTimeFuture<F>
+where
+    F: Future,
+{
+    /// Wrapped future.
+    future: F,
+    /// Unpark time tracking.
+    time: Arc<InitialUnparkTime>,
+}
+
+#[cfg(feature = "timing")]
+impl<F> InitialUnparkTimeFuture<F>
+where
+    F: Future,
+{
+    /// Creates a new instance.
+    pub fn new(future: F) -> Self {
+        Self {
+            future,
+            time: Arc::default(),
+        }
+    }
+}
+
+#[cfg(feature = "timing")]
+impl<F> Future for InitialUnparkTimeFuture<F>
+where
+    F: Future,
+{
+    type Item = (F::Item, Arc<InitialUnparkTime>);
+    type Error = F::Error;
+
+    #[inline]
+    #[allow(deprecated)]
+    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
+        let result = task::with_unpark_event(
+            task::UnparkEvent::new(Arc::clone(&self.time) as Arc<task::EventSet>, 1),
+            || self.future.poll(),
+        );
+
+        result.map(|ok| ok.map(|item| (item, Arc::clone(&self.time))))
+    }
+}
+
+/// [`EventSet`] implementation for tracking when a task is initially unparked.
+///
+/// [`EventSet`]: https://docs.rs/tokio/0.1/tokio/prelude/task/trait.EventSet.html
+#[cfg(feature = "timing")]
+#[derive(Debug, Default)]
+pub struct InitialUnparkTime {
+    /// Initial unpark time tracking.
+    time: Mutex<Option<Instant>>,
+}
+
+#[cfg(feature = "timing")]
+impl InitialUnparkTime {
+    /// Returns the time when the first unpark occurred.
+    pub fn get(&self) -> Option<Instant> {
+        *self.time.lock()
+    }
+}
+
+#[cfg(feature = "timing")]
+#[allow(deprecated)]
+impl task::EventSet for InitialUnparkTime {
+    #[inline]
+    fn insert(&self, _id: usize) {
+        let mut time_ref = self.time.lock();
+        if time_ref.is_none() {
+            *time_ref = Some(Instant::now());
+        }
     }
 }

--- a/grpc-actix/src/lib.rs
+++ b/grpc-actix/src/lib.rs
@@ -13,6 +13,9 @@ extern crate log;
 extern crate parking_lot;
 extern crate prost;
 
+#[cfg(feature = "timing")]
+extern crate tokio;
+
 #[cfg(test)]
 #[macro_use]
 extern crate prost_derive;


### PR DESCRIPTION
This adds a "timing" feature that aims to provide somewhat accurate
timing of when an HTTP request is sent for an RPC message and when the
response is received over the connection socket, primarily for
benchmarking purposes. The feature is disabled by default, so timing
code will not be enabled unless a crate explicitly requests it in its
dependencies.

In addition to the "timing" feature itself, this also updates the
Jenkins configuration to build, test, and lint the timing feature.